### PR TITLE
Add support for configuring a host with a static IP

### DIFF
--- a/backend/core/SolarProtocolClass.py
+++ b/backend/core/SolarProtocolClass.py
@@ -39,7 +39,10 @@ class SolarProtocol:
 			self.getEnvScriptPath = "/home/pi/solar-protocol/backend/get_env.sh" #this script retrieves the environmental variables
 		self.localConfigData = dict()
 		self.loadLocalConfigFile()
-		self.myIP = requests.get('https://server.solarpowerforartists.com/?myip=true').text.strip()
+		if host_ip := self.getEnv('STATIC_HOST_IP'):
+			self.myIP = host_ip
+		else:
+			self.myIP = requests.get('https://server.solarpowerforartists.com/?myip=true').text.strip()
 		#self.myIP = requests.get("https://ifconfig.co/ip").text.strip()
 		
 		# dns.solarprotocol.net isn't redirecting properly so we're using the below url for the time being

--- a/backend/core/clientPostIP.py
+++ b/backend/core/clientPostIP.py
@@ -211,7 +211,11 @@ def runClientPostIP():
 	print("*****Running ClientPostIP script*****")
 	print()
 	
-	myIP = 	requests.get('https://server.solarpowerforartists.com/?myip').text
+	if host_ip := getEnv('STATIC_HOST_IP'):
+		myIP = host_ip
+	else:
+		myIP = 	requests.get('https://server.solarpowerforartists.com/?myip').text
+
 	print("MY IP: " + myIP)
 
 	#wlan0 might need to be changed to eth0 if using an ethernet cable

--- a/local/local.md
+++ b/local/local.md
@@ -8,7 +8,7 @@ This store local variables. It can be updated as needed via the admin console. T
 
 ## .spenv
 
-This file stores network and DNS passwords
+This file stores network and DNS passwords as well as the optional `STATIC_HOST_IP` variable.
 
 ## access.json
 


### PR DESCRIPTION
This PR adds support to configure a node with an explicit static IP instead of using the IP discovery service https://server.solarpowerforartists.com/?myip. 

The host for Rhizome's Solar Protocol node for the time being is unable to configure their modem and router setup. To enable the node to still communicate with the network, I'm setting up a Cloudflare Tunnel to expose the node to the public internet. Since SP's dynamic DNS (namecheap) only supports A records (instead of a CNAME to the CF tunnel), I'm using a static IP (set with `STATIC_HOST_IP`) to reverse proxy the connection to the Cloudflare tunnel, e.g.:

```
solarprotocol.net -> [static ip] -> nginx reverse proxy -> Cloudflare tunnel -> rhizome's node
```

#### Changes:
- Add a check for the `STATIC_HOST_IP` environment variable and uses it instead of the lookup service, if present 